### PR TITLE
Unit Test 6 Failed Sun Aug 13 11:00:01 WAT 2017

### DIFF
--- a/app/league_performance.py
+++ b/app/league_performance.py
@@ -56,3 +56,6 @@ class LeastGoalPerformer(object):
 			#print goalDifList
 			return goalDifList
 		pass
+
+	def goalPerformance(self, filename):
+		pass

--- a/test/test_league_performance.py
+++ b/test/test_league_performance.py
@@ -33,6 +33,12 @@ class TddLeastGoalPerformer(unittest.TestCase):
 		self.assertIsInstance(goalDifList, list)
 		pass
 
+	def test__confirm_if_resultfile_iteration_can_produce_league_team_Name_and_goalDifference_Dictionary(self):
+		inputFilename = LeastGoalPerformer()
+		goalPerformance = inputFilename.goalPerformance('football-league-results.txt')
+		self.assertIsInstance(goalPerformance, dict)
+		pass
+
 
 
 

--- a/test_log.txt
+++ b/test_log.txt
@@ -134,3 +134,22 @@ test__return_inputFileIntegrity (test.test_league_performance.TddLeastGoalPerfor
 Ran 5 tests in 0.001s
 
 OK
+test__confirm_if_resultfile_iteration_can_produce_league_team_Name_and_goalDifference_Dictionary (test.test_league_performance.TddLeastGoalPerformer) ... FAIL
+test__return_error_if_resultfile_empty (test.test_league_performance.TddLeastGoalPerformer) ... ok
+test__return_error_if_resultfile_iteration_can_not_produce_to_league_team_goalDifference_list (test.test_league_performance.TddLeastGoalPerformer) ... ok
+test__return_error_if_resultfile_iteration_can_not_produce_to_team_list (test.test_league_performance.TddLeastGoalPerformer) ... ok
+test__return_exception_if_file_extension_not_txt (test.test_league_performance.TddLeastGoalPerformer) ... ok
+test__return_inputFileIntegrity (test.test_league_performance.TddLeastGoalPerformer) ... ok
+
+======================================================================
+FAIL: test__confirm_if_resultfile_iteration_can_produce_league_team_Name_and_goalDifference_Dictionary (test.test_league_performance.TddLeastGoalPerformer)
+----------------------------------------------------------------------
+Traceback (most recent call last):
+  File "/home/mosud/Desktop/SWESkills/tdd_basic_TestDrivenDevelopment/test/test_league_performance.py", line 39, in test__confirm_if_resultfile_iteration_can_produce_league_team_Name_and_goalDifference_Dictionary
+    self.assertIsInstance(goalPerformance, dict)
+AssertionError: None is not an instance of <type 'dict'>
+
+----------------------------------------------------------------------
+Ran 6 tests in 0.009s
+
+FAILED (failures=1)


### PR DESCRIPTION
Unit Test 6 is to confirm the Python dictionary container league club names as keys and corresponding goal difference as values 